### PR TITLE
Support CompressedImage and Stamped types

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,14 @@ Currently supports:
    ```
 
 * `sensor_msgs.msg.Image` &harr; 2/3-D `np.array`, similar to the function of `cv_bridge`, but without the dependency on `cv2`
+* `sensor_msgs.msg.CompressedImage` &rarr; `np.array`. 
 * `nav_msgs.msg.OccupancyGrid` &harr; `np.ma.array`
-* `geometry.msg.Vector3` &harr; 1-D `np.array`. `hom=True` gives `[x, y, z, 0]`
-* `geometry.msg.Point` &harr; 1-D `np.array`. `hom=True` gives `[x, y, z, 1]`
-* `geometry.msg.Quaternion` &harr; 1-D `np.array`, `[x, y, z, w]`
-* `geometry.msg.Transform` &harr; 4&times;4 `np.array`, the homogeneous transformation matrix
-* `geometry.msg.Pose` &harr; 4&times;4 `np.array`, the homogeneous transformation matrix from the origin
+* `geometry_msg.Vector3` &harr; 1-D `np.array`. `hom=True` gives `[x, y, z, 0]`
+* `geometry_msg.Point` &harr; 1-D `np.array`. `hom=True` gives `[x, y, z, 1]`
+* `geometry_msg.Quaternion` &harr; 1-D `np.array`, `[x, y, z, w]`
+* `geometry_msg.Transform` &harr; 4&times;4 `np.array`, the homogeneous transformation matrix
+* `geometry_msg.Pose` &harr; 4&times;4 `np.array`, the homogeneous transformation matrix from the origin
+* `geometry_msg.XXXXXStamped` &rarr; `np.array`.
 
 Support for more types can be added with:
 

--- a/src/ros_numpy/geometry.py
+++ b/src/ros_numpy/geometry.py
@@ -1,5 +1,6 @@
 from .registry import converts_from_numpy, converts_to_numpy
 from geometry_msgs.msg import Transform, Vector3, Quaternion, Point, Pose
+from geometry_msgs.msg import TransformStamped, Vector3Stamped, QuaternionStamped, PointStamped, PoseStamped
 from . import numpify
 
 import numpy as np
@@ -12,6 +13,10 @@ def vector3_to_numpy(msg, hom=False):
 		return np.array([msg.x, msg.y, msg.z, 0])
 	else:
 		return np.array([msg.x, msg.y, msg.z])
+
+@converts_to_numpy(Vector3Stamped)
+def vector3stamped_to_numpy(msg, hom=False):
+	return vector3_to_numpy(msg.vector, hom)
 
 @converts_from_numpy(Vector3)
 def numpy_to_vector3(arr):
@@ -31,6 +36,10 @@ def point_to_numpy(msg, hom=False):
 	else:
 		return np.array([msg.x, msg.y, msg.z])
 
+@converts_to_numpy(PointStamped)
+def pointstamped_to_numpy(msg, hom=False):
+	return point_to_numpy(msg.point, hom)
+
 @converts_from_numpy(Point)
 def numpy_to_point(arr):
 	if arr.shape[-1] == 4:
@@ -44,6 +53,10 @@ def numpy_to_point(arr):
 @converts_to_numpy(Quaternion)
 def quat_to_numpy(msg):
 	return np.array([msg.x, msg.y, msg.z, msg.w])
+
+@converts_to_numpy(QuaternionStamped)
+def quatstamped_to_numpy(msg):
+	return quat_to_numpy(msg.quaternion)
 
 @converts_from_numpy(Quaternion)
 def numpy_to_quat(arr):
@@ -66,6 +79,10 @@ def transform_to_numpy(msg):
         transformations.translation_matrix(numpify(msg.translation)),
         transformations.quaternion_matrix(numpify(msg.rotation))
     )
+
+@converts_to_numpy(TransformStamped)
+def transformstamped_to_numpy(msg):
+	return transform_to_numpy(msg.transform)
 
 @converts_from_numpy(Transform)
 def numpy_to_transform(arr):
@@ -98,6 +115,10 @@ def pose_to_numpy(msg):
         transformations.translation_matrix(numpify(msg.position)),
         transformations.quaternion_matrix(numpify(msg.orientation))
     )
+
+@converts_to_numpy(PoseStamped)
+def posestamped_to_numpy(msg):
+	return pose_to_numpy(msg.pose)
 
 @converts_from_numpy(Pose)
 def numpy_to_pose(arr):

--- a/src/ros_numpy/image.py
+++ b/src/ros_numpy/image.py
@@ -1,7 +1,7 @@
 import sys
 
 from .registry import converts_from_numpy, converts_to_numpy
-from sensor_msgs.msg import Image
+from sensor_msgs.msg import Image, CompressedImage
 
 import numpy as np
 from numpy.lib.stride_tricks import as_strided
@@ -80,6 +80,9 @@ def image_to_numpy(msg):
 		data = data[...,0]
 	return data
 
+@converts_to_numpy(CompressedImage)
+def compressed_image_to_numpy(msg):
+	return np.fromstring(msg.data, np.uint8)
 
 @converts_from_numpy(Image)
 def numpy_to_image(arr, encoding):

--- a/src/ros_numpy/image.py
+++ b/src/ros_numpy/image.py
@@ -69,7 +69,7 @@ def image_to_numpy(msg):
 	dtype = dtype.newbyteorder('>' if msg.is_bigendian else '<')
 	shape = (msg.height, msg.width, channels)
 
-	data = np.fromstring(msg.data, dtype=dtype).reshape(shape)
+	data = np.frombuffer(msg.data, dtype=dtype).reshape(shape)
 	data.strides = (
 		msg.step,
 		dtype.itemsize * channels,


### PR DESCRIPTION
Following up https://github.com/eric-wieser/ros_numpy/pull/3 but only adding CompressedImage and the XXXXStamped types.