### PR TITLE
Only run tests if tests are enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,5 +177,7 @@ catkin_package(
 #   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
 # endif()
 
-## Add folders to be run by python nosetests
-catkin_add_nosetests(test)
+if(CATKIN_ENABLE_TESTING)
+  ## Add folders to be run by python nosetests
+  catkin_add_nosetests(test)
+endif()


### PR DESCRIPTION
On a system where tests are not run by default `ros_numpy` fails to build with:
```
CMake Error at /home/nao/gentoo/opt/ros/kinetic/share/catkin/cmake/test/tests.cmake:18 (message):
  () is not available when tests are not enabled.  The CMake code should only
  use it inside a conditional block which checks that testing is enabled:

  if(CATKIN_ENABLE_TESTING)

    (...)

  endif()

Call Stack (most recent call first):
  CMakeLists.txt:181 (catkin_add_nosetests)
```
So... just following with what is suggested.