### PR TITLE
migrate to package format 3 and make python-numpy conditional on the …

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<package>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>ros_numpy</name>
   <version>0.0.4</version>
   <description>A collection of conversion function for extracting numpy arrays from messages</description>
@@ -15,12 +18,13 @@
 
   <author email="wieser@mit.edu">Eric Wieser</author>
 
-  <run_depend>python-numpy</run_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>nav_msgs</run_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>tf</run_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>nav_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>tf</exec_depend>
 
   <buildtool_depend>catkin</buildtool_depend>
 


### PR DESCRIPTION
…ROS_PYTHON_VERSION

Introspecting Python 2 dependencies in ROS Noetic, found that this package depends on python-numpy instead of its python3 counterpart.

This PR makes the dependency conditional on the ROS_PYTHON_VERSION.
SImilar to https://github.com/team-vigir/flexbe_behavior_engine/pull/144

This is a semi-automated PR that has not been tested