### PR TITLE
fix: numpy float deprectation

### DIFF
--- a/src/ros_numpy/point_cloud2.py
+++ b/src/ros_numpy/point_cloud2.py
@@ -221,7 +221,7 @@ def split_rgb_field(cloud_arr):
             new_cloud_arr[field_name] = cloud_arr[field_name]
     return new_cloud_arr
 
-def get_xyz_points(cloud_array, remove_nans=True, dtype=np.float):
+def get_xyz_points(cloud_array, remove_nans=True, dtype=np.float32):
     '''Pulls out x, y, and z columns from the cloud recordarray, and returns
 	a 3xN matrix.
     '''


### PR DESCRIPTION
Latest numpy release deprecates `np.float`, see: https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations

This MR aims to solve this deprecation issue by replacing `np.float` by `np.float32`.