### PR TITLE
change np.float to np.float32

### DIFF
--- a/src/ros_numpy/point_cloud2.py
+++ b/src/ros_numpy/point_cloud2.py
@@ -221,7 +221,7 @@ def split_rgb_field(cloud_arr):
             new_cloud_arr[field_name] = cloud_arr[field_name]
     return new_cloud_arr
 
-def get_xyz_points(cloud_array, remove_nans=True, dtype=np.float):
+def get_xyz_points(cloud_array, remove_nans=True, dtype=float):
     '''Pulls out x, y, and z columns from the cloud recordarray, and returns
 	a 3xN matrix.
     '''


### PR DESCRIPTION
Since numpy 1.20, using `np.float` is deprecated. With newer versions (tested on Python 3.8.10, numpy 1.24) this lead to the following error message:

> Traceback (most recent call last):
>   File "<stdin>", line 1, in <module>
>   File "/home/luca/tiago_public_ws/devel/lib/python3/dist-packages/ros_numpy/__init__.py", line 34, in <module>
>     exec(__fh.read())
>   File "<string>", line 7, in <module>
>   File "/home/luca/tiago_public_ws/src/ros_numpy/src/ros_numpy/point_cloud2.py", line 224, in <module>
>     def get_xyz_points(cloud_array, remove_nans=True, dtype=np.float):
>   File "/home/luca/.local/lib/python3.8/site-packages/numpy/__init__.py", line 305, in __getattr__
>     raise AttributeError(__former_attrs__[attr])
> AttributeError: module 'numpy' has no attribute 'float'.
> `np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
> The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
>     https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

Replacing the `np.float` alias with `float` makes the package compatible also with newer numpy versions.