### PR TITLE
Hotfix: update the code to accept the numpy v1.24>

### DIFF
--- a/src/ros_numpy/point_cloud2.py
+++ b/src/ros_numpy/point_cloud2.py
@@ -221,7 +221,7 @@ def split_rgb_field(cloud_arr):
             new_cloud_arr[field_name] = cloud_arr[field_name]
     return new_cloud_arr
 
-def get_xyz_points(cloud_array, remove_nans=True, dtype=np.float):
+def get_xyz_points(cloud_array, remove_nans=True, dtype=float):
     '''Pulls out x, y, and z columns from the cloud recordarray, and returns
 	a 3xN matrix.
     '''


### PR DESCRIPTION
**AttributeError: module 'numpy' has no attribute 'float'**

To reproduce this error you must have the Numpy v1.24.0 and try to import the ros_numpy in your code.
The correction was change the _np.float_ as default dtype to the Python builtin type _float_ in get_xyz_points function.