### PR TITLE
Sort fields by offset in fields_to_type()

### DIFF
--- a/src/ros_numpy/point_cloud2.py
+++ b/src/ros_numpy/point_cloud2.py
@@ -63,7 +63,7 @@ def fields_to_dtype(fields, point_step):
     '''
     offset = 0
     np_dtype_list = []
-    for f in fields:
+    for f in sorted(fields, key=lambda _f: _f.offset):
         while offset < f.offset:
             # might be extra padding between fields
             np_dtype_list.append(('%s%d' % (DUMMY_FIELD_PREFIX, offset), np.uint8))


### PR DESCRIPTION
Closes https://github.com/eric-wieser/ros_numpy/issues/40.

As discussed in above issue `fields_to_type` does return incorrect data when fields are not sorted by offset. For example [perception_plc](https://github.com/ros-perception/perception_pcl/issues/434) does not require the fields to be sorted and can produce unsorted messages. While I strongly believe that the sorting should happen on message creation (how else would they be sorted in a meaningful way), it can not and probably should not be assumed to be done that way.

This merge request would fix that.
